### PR TITLE
Modify API endpoint for assigning sentiment to a thought on creation

### DIFF
--- a/app/models/thought.rb
+++ b/app/models/thought.rb
@@ -1,4 +1,4 @@
 class Thought < ApplicationRecord
-  acts_as_taggable_on :labels
+  acts_as_taggable_on :labels, :sentiments
   validates :title, :body, presence: true
 end

--- a/spec/models/thought_spec.rb
+++ b/spec/models/thought_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Thought, type: :model do
 
   describe 'Relations' do
     it { is_expected.to have_many :labels }
+    it { is_expected.to have_many :sentiments }
   end
 
   describe FactoryBot do

--- a/spec/requests/api/v1/thought_spec.rb
+++ b/spec/requests/api/v1/thought_spec.rb
@@ -7,7 +7,9 @@ RSpec.describe Api::V1::ThoughtsController, type: :request do
     it 'creates a thought' do
       post '/api/v1/thoughts', params: {
         thought: {
-          title: "Hello", body: "World", label_list: "Family"
+          title: "Hello", body: "World",
+          label_list: "Family, Music",
+          sentiment_list: "Happy"
         }
       }, headers: headers
 
@@ -18,7 +20,9 @@ RSpec.describe Api::V1::ThoughtsController, type: :request do
     it 'creates a thought without title' do
       post '/api/v1/thoughts', params: {
         thought: {
-          body: "World", label_list: "Family"
+          body: "World",
+          label_list: "Family",
+          sentiment_list: "Sad"
         }
       }, headers: headers
 
@@ -29,7 +33,9 @@ RSpec.describe Api::V1::ThoughtsController, type: :request do
     it 'creates a thought without body' do
       post '/api/v1/thoughts', params: {
         thought: {
-          title: "Hello", label_list: "Family"
+          title: "Hello",
+          label_list: "Family",
+          sentiment_list: "Excited"
         }
       }, headers: headers
 


### PR DESCRIPTION
## PT-Link: https://www.pivotaltracker.com/story/show/154699944

## Description:
Add sentiment as tag list to thought model

