### PR TITLE
Setup API Endpoint for deleting thought

### DIFF
--- a/app/controllers/api/v1/thoughts_controller.rb
+++ b/app/controllers/api/v1/thoughts_controller.rb
@@ -19,6 +19,11 @@ class Api::V1::ThoughtsController < ApplicationController
     render json: thought, serializer: ThoughtsSerializer
   end
 
+  def destroy
+    thought = Thought.find(params[:id]).delete
+    render json: { message: "#{thought.title} has been successfully deleted." }
+  end
+
   private
 
   def thought_params

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
     end
     namespace :v1, defaults: { format: :json } do
       mount_devise_token_auth_for 'User', at: 'auth', skip: [:omniauth_callbacks]
-      resources :thoughts, only: [:create, :show]
+      resources :thoughts, only: [:create, :show, :destroy]
       resources :labels, only: [:index, :show]
       resources :sentiments, only: [:index, :show]
       resources :history, only: [:index]

--- a/spec/fixtures/files/thought_delete.txt
+++ b/spec/fixtures/files/thought_delete.txt
@@ -1,0 +1,1 @@
+{"message"=>"MyString has been successfully deleted."}

--- a/spec/requests/api/v1/thought_spec.rb
+++ b/spec/requests/api/v1/thought_spec.rb
@@ -58,16 +58,26 @@ RSpec.describe Api::V1::ThoughtsController, type: :request do
     end
   end
 
-  describe 'GET /v1/thoughts/thought_id' do
+  context 'Specific thoughts' do
     before do
       FactoryBot.create(:thought, user: user)
     end
+    describe 'GET /v1/thoughts/thought_id' do
+      it 'returns a specific thought' do
+        get "/api/v1/thoughts/#{Thought.last.id}", headers: headers
+        expect(response.status).to eq 200
+        expected_response = eval(file_fixture('thoughts_show.txt').read)
+        expect(response_json).to eq expected_response.as_json
+      end
+    end
 
-    it 'returns a specific thought' do
-      get "/api/v1/thoughts/#{Thought.last.id}", headers: headers
-      expect(response.status).to eq 200
-      expected_response = eval(file_fixture('thoughts_show.txt').read)
-      expect(response_json).to eq expected_response.as_json
+    describe 'DELETE /v1/thoughts/thought_id' do
+      it 'deletes a specific thought' do
+        delete "/api/v1/thoughts/#{Thought.last.id}", headers: headers
+        expect(response.status).to eq 200
+        expected_response = eval(file_fixture('thought_delete.txt').read)
+        expect(response_json).to eq expected_response.as_json
+      end
     end
   end
 end


### PR DESCRIPTION
## PT-Link: https://www.pivotaltracker.com/story/show/154898888

## Description:
Add delete functionality for a specific thought.