### PR TITLE
Setup API Endpoint for updating thought

### DIFF
--- a/app/controllers/api/v1/thoughts_controller.rb
+++ b/app/controllers/api/v1/thoughts_controller.rb
@@ -29,6 +29,16 @@ class Api::V1::ThoughtsController < ApplicationController
     render json: thoughts, each_serializer: ThoughtsSerializer
   end
 
+  def update
+    thought = Thought.find(params[:id])
+    if thought.update(thought_params)
+      render json: { message: "#{thought.title} has been successfully updated." }
+    else
+      render json: { error: thought.errors.full_messages },
+             status: 422
+    end
+  end
+
   private
 
   def thought_params

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
     end
     namespace :v1, defaults: { format: :json } do
       mount_devise_token_auth_for 'User', at: 'auth', skip: [:omniauth_callbacks]
-      resources :thoughts, only: [:create, :show, :index, :destroy]
+      resources :thoughts, only: [:create, :show, :index, :destroy, :update]
       resources :labels, only: [:index, :show]
       resources :sentiments, only: [:index, :show]
       resources :history, only: [:index]

--- a/spec/fixtures/files/edit_thought.txt
+++ b/spec/fixtures/files/edit_thought.txt
@@ -1,0 +1,1 @@
+{"message"=>"New title has been successfully updated."}

--- a/spec/requests/api/v1/thought_spec.rb
+++ b/spec/requests/api/v1/thought_spec.rb
@@ -96,4 +96,31 @@ RSpec.describe Api::V1::ThoughtsController, type: :request do
       expect(response_json).to eq expected_response.as_json
     end
   end
+
+  describe 'GET /v1/thoughts/thought_id' do
+    it 'edits a specific thought' do
+      put "/api/v1/thoughts/#{Thought.last.id}", params: {
+        thought: { title: 'New title', body: 'New body' }
+      }, headers: headers
+      expect(response.status).to eq 200
+      expected_response = eval(file_fixture('edit_thought.txt').read)
+      expect(response_json).to eq expected_response.as_json
+    end
+
+    it 'does not edit if title is blank' do
+      put "/api/v1/thoughts/#{Thought.last.id}", params: {
+        thought: { title: '', body: 'New Body' }
+      }, headers: headers
+      expect(response.status).to eq 422
+      expect(response_json['error']).to eq ["Title can't be blank"]
+    end
+
+    it 'does not edit if body is blank' do
+      put "/api/v1/thoughts/#{Thought.last.id}", params: {
+        thought: { title: 'New title', body: '' }
+      }, headers: headers
+      expect(response.status).to eq 422
+      expect(response_json['error']).to eq ["Body can't be blank"]
+    end
+  end
 end


### PR DESCRIPTION
## PT-Link: https://www.pivotaltracker.com/story/show/154904190

## Description:
Add endpoint to allow user's to update a specific thought.