### PR TITLE
Setup API Endpoint for getting sentiment stats for last month

### DIFF
--- a/app/controllers/api/v1/sentiments_controller.rb
+++ b/app/controllers/api/v1/sentiments_controller.rb
@@ -17,4 +17,15 @@ class Api::V1::SentimentsController < ApplicationController
     thoughts = current_api_v1_user.thoughts.tagged_with(sentiment.name)
     render json: thoughts, each_serializer: ThoughtsSerializer
   end
+
+  def statistics
+    sentiment_list = []
+    current_api_v1_user.thoughts.where("created_at >= ?", 1.month.ago).each do |thought|
+      if sentiment_list.none? { |sentiment| sentiment.name == thought.sentiments[0].name }
+        thought.sentiments[0].taggings_count = current_api_v1_user.thoughts.tagged_with(thought.sentiments[0].name).count
+        sentiment_list << thought.sentiments[0]
+      end
+    end
+    render json: { sentiments: sentiment_list}
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
       mount_devise_token_auth_for 'User', at: 'auth', skip: [:omniauth_callbacks]
       resources :thoughts, only: [:create, :show, :index, :destroy, :update]
       resources :labels, only: [:index, :show]
+      get '/sentiments/statistics', to: 'sentiments#statistics'
       resources :sentiments, only: [:index, :show]
       resources :history, only: [:index]
     end

--- a/spec/fixtures/files/sentiments_for_last_month.txt
+++ b/spec/fixtures/files/sentiments_for_last_month.txt
@@ -1,0 +1,1 @@
+{"sentiments"=>[{"id"=>Thought.first.sentiments[0].id, "name"=>"Happy", "taggings_count"=>3}]}

--- a/spec/requests/api/v1/sentiments_spec.rb
+++ b/spec/requests/api/v1/sentiments_spec.rb
@@ -23,4 +23,13 @@ RSpec.describe Api::V1::SentimentsController, type: :request do
       expect(response_json).to eq expected_response.as_json
     end
   end
+
+  describe 'GET /v1/sentiments/statistics' do
+    it 'should return all sentiments from the last month' do
+      get '/api/v1/sentiments/statistics', headers: headers
+      expect(response.status).to eq 200
+      expected_response = eval(file_fixture('sentiments_for_last_month.txt').read)
+      expect(response_json).to eq expected_response.as_json
+    end
+  end
 end


### PR DESCRIPTION
### PT-Link: https://www.pivotaltracker.com/story/show/154904651
### Description: 
Sets up 'statistics' route for getting sentiments stats for last month