### PR TITLE
Setup API Endpoint for getting thoughts for last seven days

### DIFF
--- a/app/controllers/api/v1/activity_controller.rb
+++ b/app/controllers/api/v1/activity_controller.rb
@@ -1,0 +1,15 @@
+class Api::V1::ActivityController < ApplicationController
+  def index
+    entry_list = []
+    date = Date.today
+    count = 6
+    while count > -1
+      entry = { amount: current_api_v1_user.entries.select do |entry|
+        Date.parse(entry.created_at.to_s) == date - count
+      end.count, date: date - count }
+      entry_list << entry
+      count -= 1
+    end
+    render json: { week: entry_list }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,10 @@
 Rails.application.routes.draw do
+  namespace :api do
+    namespace :v1 do
+      get 'activity/index'
+    end
+  end
+
   mount_devise_token_auth_for 'User', at: 'auth'
   namespace :api do
     namespace :v0 do
@@ -11,6 +17,7 @@ Rails.application.routes.draw do
       get '/sentiments/statistics', to: 'sentiments#statistics'
       resources :sentiments, only: [:index, :show]
       resources :history, only: [:index]
+      resources :activity, only: [:index]
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,4 @@
 Rails.application.routes.draw do
-  namespace :api do
-    namespace :v1 do
-      get 'activity/index'
-    end
-  end
-
   mount_devise_token_auth_for 'User', at: 'auth'
   namespace :api do
     namespace :v0 do

--- a/spec/fixtures/files/entries_for_week.txt
+++ b/spec/fixtures/files/entries_for_week.txt
@@ -1,0 +1,8 @@
+{"week"=>
+  [{"amount"=>0, "date"=>"#{Date.today - 6}"},
+   {"amount"=>0, "date"=>"#{Date.today - 5}"},
+   {"amount"=>2, "date"=>"#{Date.today - 4}"},
+   {"amount"=>0, "date"=>"#{Date.today - 3}"},
+   {"amount"=>0, "date"=>"#{Date.today - 2}"},
+   {"amount"=>5, "date"=>"#{Date.today - 1}"},
+   {"amount"=>0, "date"=>"#{Date.today}"}]}

--- a/spec/requests/api/v1/activity_spec.rb
+++ b/spec/requests/api/v1/activity_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe Api::V1::ActivityController, type: :request do
+  let(:user) { FactoryBot.create(:user)}
+  let(:credentials) { user.create_new_auth_token }
+  let(:headers) { { HTTP_ACCEPT: 'application/json'}.merge!(credentials) }
+  before do
+    5.times { FactoryBot.create(:entry, user: user, created_at: Date.yesterday) }
+    2.times { FactoryBot.create(:entry, user: user, created_at: Date.today - 4) }
+  end
+
+  describe 'GET /v1/activity' do
+    it 'returns thoughts for each day over the past week' do
+      get '/api/v1/activity', headers: headers
+      expect(response.status).to eq 200
+      expected_response = eval(file_fixture('entries_for_week.txt').read)
+      expect(response_json).to eq expected_response.as_json
+    end
+  end
+end


### PR DESCRIPTION
## PT-Link: https://www.pivotaltracker.com/story/show/154956067

## Description:
Add api endpoint to fetch the number of thoughts for each day from the last week for a specific user.